### PR TITLE
Removes requirement that /config dir be mounted.

### DIFF
--- a/root/etc/cont-init.d/20-cron.sh
+++ b/root/etc/cont-init.d/20-cron.sh
@@ -13,12 +13,6 @@ ERROR: '/download' directory must be mounted
 "
 	exit 1
 fi
-if [ ! -d /config ]; then
-	echo "
-ERROR: '/config' directory must be mounted
-"
-	exit 1
-fi
 
 if [ -z "$HEALTHCHECK_ID" ]; then
 	echo "


### PR DESCRIPTION
This image doesn't use the `config` directory.  I didn't swap it out for the `/tmp/gphotos-cdp` directory, because I wasn't sure if that was a hard requirement of the container.  It probably is, since chrome runs headless, so let me know if you'd like me to add that.