### PR TITLE
Update cdp version to fix -headless auth error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN wget http://www.sentex.net/~mwandel/jhead/jhead-$JHEAD_VERSION.tar.gz \
     && make install
 
 ENV GO111MODULE=on
-RUN go install github.com/perkeep/gphotos-cdp@e9d1979707191993f1c879ae93f8dd810697fd6e
+RUN go install github.com/spraot/gphotos-cdp@29df3918
 
 
 FROM crazymax/alpine-s6:3.17-edge


### PR DESCRIPTION
This fixes #25 

I also will create a PR at gphotos-cdp so that this code can point at the main repo again. The relevant change is here: https://github.com/spraot/gphotos-cdp/commit/5a65d60f3c732a5e95b3a973534f4d2999fec8dc